### PR TITLE
Add input to define the OS of the runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,3 @@ jobs:
       - name: Build with Maven
         run: mvn -V -B verify
 ```
-
-### Define the Operative System
-```
-    - name: Setup testcontainers-cloud
-        uses: atomicjar/testcontainers-cloud-setup-action@main
-        with:
-          os: windows
-        
-```


### PR DESCRIPTION
This PR is totally optional but I thought it could be useful to be able to specify the OS of the runner instead of using always linux. WDYT?

I also changed the way how the `suffix` is calculated. You can see more details [here](https://atomicjar.slack.com/archives/C021MAAP8BY/p1664780823035999).

If you keep reading in the thread you will see another approach to determine the binary to use (using url aliases), let us know what do you think as well 🙏 