### PR TITLE
Add support for TCC_PROJECT_KEY and TCC_PROJECT_URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
           project-key: testcontainers-cloud-setup-action-custom
           project-url: https://testcontainers.cloud
 
-  with-project-keys-en-vars:
+  with-project-keys-as-env-vars:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,3 +97,17 @@ jobs:
           name: output-log-file
           path: testcontainers-client.log
           retention-days: 30
+
+  with-project-keys:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Testcontainers Cloud Client with project-key and project-url
+        uses: ./
+        with:
+          version: next
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+          project-key: test
+          project-url: https://testcontainers.cloud

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,3 +110,17 @@ jobs:
           token: ${{ secrets.TC_CLOUD_TOKEN }}
           project-key: testcontainers-cloud-setup-action-custom
           project-url: https://testcontainers.cloud
+
+  with-project-keys-en-vars:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Testcontainers Cloud Client with project-key and project-url
+        uses: ./
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+        env:
+          TCC_PROJECT_KEY: testcontainers-cloud-setup-action-custom-env-var
+          TCC_PROJECT_URL: https://testcontainers.cloud

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Setup Testcontainers Cloud Client with project-key and project-url
         uses: ./
         with:
-          version: next
           token: ${{ secrets.TC_CLOUD_TOKEN }}
           project-key: test
           project-url: https://testcontainers.cloud

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,5 +108,5 @@ jobs:
         uses: ./
         with:
           token: ${{ secrets.TC_CLOUD_TOKEN }}
-          project-key: test
+          project-key: testcontainers-cloud-setup-action-custom
           project-url: https://testcontainers.cloud

--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ jobs:
 - `args` (_optional_): `string` - flags/arguments of the agent to pass as is. Consult with the knowledge base to find out more about possible options.
 - `logfile` (_optional_): `string` - file to write the agent output instead of the standard out.
 - `action` (_optional_): `prepare` (default) / `terminate` - action could be specified explicitly to terminate sessions eagerly.
+- `project-key` (_optional_): `GITHUB_REPOSITORY` (default) - project identifier
+- `project-url` (_optional_): `GITHUB_SERVER_URL/GITHUB_REPOSITORY` (default) - project's url

--- a/action.yml
+++ b/action.yml
@@ -33,21 +33,22 @@ runs:
   using: 'composite'
   steps:
     - id: testcontainers-cloud-env-vars
-      name: Preparing Testcontainers env vars
+      name: Preparing Testcontainers Cloud env vars
       shell: bash
       run: |
+        # prepare tcc env vars
         projectKey="$GITHUB_REPOSITORY"
 
-        if [ -v INPUT_PROJECT-KEY ]; then
-          projectKey="$INPUT_PROJECT-KEY"
+        if [ -v ${{ inputs.project-key }} ]; then
+          projectKey="$${{ inputs.project-key }}"
         elif [ -v TCC_PROJECT_KEY ]; then
           projectKey="$TCC_PROJECT_KEY"
         fi
 
         projectUrl="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
 
-        if [ -v INPUT_PROJECT-URL ]; then
-          projectUrl="$INPUT_PROJECT-URL"
+        if [ -v ${{ inputs.project-url }} ]; then
+          projectUrl="${{ inputs.project-url }}"
         elif [ -v TCC_PROJECT_URL ]; then
           projectUrl="$TCC_PROJECT_URL"
         fi

--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,8 @@ runs:
         TC_CLOUD_TOKEN: ${{ inputs.token || env.TC_CLOUD_TOKEN }}
         TC_CLOUD_LOGS_ENABLE_COLORS: 'true'
         TCC_BINARY_NAME: ${{ env.TCC_BINARY_NAME || 'tcc-agent' }}
-        TCC_PROJECT_KEY: ${{ inputs.project-key || $GITHUB_REPOSITORY }}
-        TCC_PROJECT_URL: ${{ inputs.project-url || format('{0}/{1}', $GITHUB_SERVER_URL, $GITHUB_REPOSITORY) }}
+        TCC_PROJECT_KEY: ${{ inputs.project-key || env.TCC_PROJECT_KEY || env.GITHUB_REPOSITORY }}
+        TCC_PROJECT_URL: ${{ inputs.project-url || env.TCC_PROJECT_URL || format('{0}/{1}', env.GITHUB_SERVER_URL, env.GITHUB_REPOSITORY) }}
       if: inputs.action == 'prepare'
       run: |
         # download and run the agent at the background

--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,8 @@ runs:
         TC_CLOUD_TOKEN: ${{ inputs.token || env.TC_CLOUD_TOKEN }}
         TC_CLOUD_LOGS_ENABLE_COLORS: 'true'
         TCC_BINARY_NAME: ${{ env.TCC_BINARY_NAME || 'tcc-agent' }}
-        TCC_PROJECT_KEY: ${{ inputs.project-key || env.GITHUB_REPOSITORY }}
-        TCC_PROJECT_URL: ${{ inputs.project-url || format('{0}/{1}', env.GITHUB_SERVER_URL, env.GITHUB_REPOSITORY) }}
+        TCC_PROJECT_KEY: ${{ inputs.project-key || $GITHUB_REPOSITORY }}
+        TCC_PROJECT_URL: ${{ inputs.project-url || format('{0}/{1}', $GITHUB_SERVER_URL, $GITHUB_REPOSITORY) }}
       if: inputs.action == 'prepare'
       run: |
         # download and run the agent at the background

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,28 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - id: testcontainers-cloud-env-vars
+      name: Preparing Testcontainers env vars
+      shell: bash
+      run: |
+        projectKey="$GITHUB_REPOSITORY"
+
+        if [ -v INPUT_TCC_PROJECT_KEY ]; then
+          projectKey="$INPUT_TCC_PROJECT_KEY"
+        elif [ -v TCC_PROJECT_KEY ]; then
+          projectKey="$TCC_PROJECT_KEY"
+        fi
+
+        projectUrl="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+
+        if [ -v INPUT_TCC_PROJECT_URL ]; then
+          projectUrl="$INPUT_TCC_PROJECT_URL"
+        elif [ -v TCC_PROJECT_URL ]; then
+          projectUrl="$TCC_PROJECT_URL"
+        fi
+
+        echo "TCC_PROJECT_KEY=${projectKey}" >> $GITHUB_ENV
+        echo "TCC_PROJECT_URL=${projectUrl}" >> $GITHUB_ENV
     - id: testcontainers-cloud
       name: Download and run Testcontainers Cloud Client
       shell: bash
@@ -39,8 +61,6 @@ runs:
         TC_CLOUD_TOKEN: ${{ inputs.token || env.TC_CLOUD_TOKEN }}
         TC_CLOUD_LOGS_ENABLE_COLORS: 'true'
         TCC_BINARY_NAME: ${{ env.TCC_BINARY_NAME || 'tcc-agent' }}
-        TCC_PROJECT_KEY: ${{ inputs.project-key || env.TCC_PROJECT_KEY || env.GITHUB_REPOSITORY }}
-        TCC_PROJECT_URL: ${{ inputs.project-url || env.TCC_PROJECT_URL || format('{0}/{1}', env.GITHUB_SERVER_URL, env.GITHUB_REPOSITORY) }}
       if: inputs.action == 'prepare'
       run: |
         # download and run the agent at the background

--- a/action.yml
+++ b/action.yml
@@ -38,16 +38,16 @@ runs:
       run: |
         projectKey="$GITHUB_REPOSITORY"
 
-        if [ -v INPUT_TCC_PROJECT_KEY ]; then
-          projectKey="$INPUT_TCC_PROJECT_KEY"
+        if [ -v INPUT_PROJECT-KEY ]; then
+          projectKey="$INPUT_PROJECT-KEY"
         elif [ -v TCC_PROJECT_KEY ]; then
           projectKey="$TCC_PROJECT_KEY"
         fi
 
         projectUrl="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
 
-        if [ -v INPUT_TCC_PROJECT_URL ]; then
-          projectUrl="$INPUT_TCC_PROJECT_URL"
+        if [ -v INPUT_PROJECT-URL ]; then
+          projectUrl="$INPUT_PROJECT-URL"
         elif [ -v TCC_PROJECT_URL ]; then
           projectUrl="$TCC_PROJECT_URL"
         fi

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         TC_CLOUD_LOGS_ENABLE_COLORS: 'true'
         TCC_BINARY_NAME: ${{ env.TCC_BINARY_NAME || 'tcc-agent' }}
         TCC_PROJECT_KEY: ${{ inputs.project-key || env.GITHUB_REPOSITORY }}
-        TCC_PROJECT_URL: ${{ inputs.project-url || env.GITHUB_SERVER_URL/env.GITHUB_REPOSITORY }}
+        TCC_PROJECT_URL: ${{ inputs.project-url || format('{0}/{1}', env.GITHUB_SERVER_URL, env.GITHUB_REPOSITORY) }}
       if: inputs.action == 'prepare'
       run: |
         # download and run the agent at the background

--- a/action.yml
+++ b/action.yml
@@ -39,22 +39,25 @@ runs:
         # prepare tcc env vars
         projectKey="$GITHUB_REPOSITORY"
 
-        if [ -v ${{ inputs.project-key }} ]; then
-          projectKey="$${{ inputs.project-key }}"
-        elif [ -v TCC_PROJECT_KEY ]; then
+        if [[ ! -z "$INPUT_PROJECT_KEY" ]]; then
+          projectKey="$INPUT_PROJECT_KEY"
+        elif [[ ! -z "$TCC_PROJECT_KEY" ]]; then
           projectKey="$TCC_PROJECT_KEY"
         fi
 
         projectUrl="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
 
-        if [ -v ${{ inputs.project-url }} ]; then
-          projectUrl="${{ inputs.project-url }}"
-        elif [ -v TCC_PROJECT_URL ]; then
+        if [[ ! -z "$INPUT_PROJECT_URL" ]]; then
+          projectUrl="$INPUT_PROJECT_URL"
+        elif [[ ! -z "$TCC_PROJECT_URL" ]]; then
           projectUrl="$TCC_PROJECT_URL"
         fi
 
         echo "TCC_PROJECT_KEY=${projectKey}" >> $GITHUB_ENV
         echo "TCC_PROJECT_URL=${projectUrl}" >> $GITHUB_ENV
+      env:
+        INPUT_PROJECT_KEY: ${{ inputs.project-key }}
+        INPUT_PROJECT_URL: ${{ inputs.project-url }}
     - id: testcontainers-cloud
       name: Download and run Testcontainers Cloud Client
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
     description: 'What should be done exactly: prepare|terminate'
     required: false
     default: prepare
+  project-key:
+    description: 'Project identifier'
+    required: false
+  project-url:
+    description: 'Project URL'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -33,6 +39,8 @@ runs:
         TC_CLOUD_TOKEN: ${{ inputs.token || env.TC_CLOUD_TOKEN }}
         TC_CLOUD_LOGS_ENABLE_COLORS: 'true'
         TCC_BINARY_NAME: ${{ env.TCC_BINARY_NAME || 'tcc-agent' }}
+        TCC_PROJECT_KEY: ${{ inputs.project-key || env.GITHUB_REPOSITORY }}
+        TCC_PROJECT_URL: ${{ inputs.project-url || env.GITHUB_SERVER_URL/env.GITHUB_REPOSITORY }}
       if: inputs.action == 'prepare'
       run: |
         # download and run the agent at the background


### PR DESCRIPTION
The tcc agent supports `TCC_PROJECT_KEY` and `TCC_PROJECT_URL`. By
using the GHA, those will be populated with the following default values:

* `TCC_PROJECT_KEY`: `GITHUB_REPOSITORY` env var
* `TCC_PROJECT_URL`: `GITHUB_SERVER_URL/GITHUB_REPOSITORY`

Also, those can be set by the action configuration by using: `project-key`
and `project-url`.

Another step was added to set the right env vars. See https://github.com/actions/runner/issues/665#issuecomment-676581170

Fixes https://github.com/AtomicJar/testcontainers-cloud-setup-action/issues/8