### PR TITLE
CLOUD-236 By default do not execute wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
 
 - `token` (__required__):  `secret-string` - service account token for Testcontainers Cloud
 - `version` (_optional_):  `latest` (default) - Testcontainers Cloud binary version
-- `wait` (_optional_):  `true` (default) /`false` - if action should wait until agent successfully connects to Testcontainers Cloud in advance
+- `wait` (_optional_):  `true`/`false` (default) - if action should wait until agent successfully connects to Testcontainers Cloud in advance
 - `args` (_optional_): `string` - flags/arguments of the agent to pass as is. Consult with the knowledge base to find out more about possible options.
 - `logfile` (_optional_): `string` - file to write the agent output instead of the standard out.
 - `action` (_optional_): `prepare` (default) / `terminate` - action could be specified explicitly to terminate sessions eagerly.

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   wait:
     description: 'If Testcontainers Cloud Client should wait for a connection before proceeding'
     required: false
-    default: 'true'
+    default: 'false'
   args:
     description: 'Additional Testcontainers Cloud Client args, not explicitly defined in the action'
     required: false


### PR DESCRIPTION
This approach used to be useful while we improved the reliability of TCC. We can now simplify the setup by removing it, which should also get rid of some empty leases (e.g. when a build does not use TC for whatever reasons) and users accidentally sharing the wait logs with us in debugging scenarios.