### PR TITLE
Add retries for downloading the TCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ jobs:
 - `action` (_optional_): `prepare` (default) / `terminate` - action could be specified explicitly to terminate sessions eagerly.
 - `project-key` (_optional_): `GITHUB_REPOSITORY` (default) - project identifier
 - `project-url` (_optional_): `GITHUB_SERVER_URL/GITHUB_REPOSITORY` (default) - project's url
+- `download-retries` (_optional_): `1` (default) - number of retry attempts to download Testcontainers Cloud Client before giving up.

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
   project-url:
     description: 'Project URL'
     required: false
+  retry-attempts:
+    description: 'The number of retry attempts to download Testcontainers Cloud Client before giving up'
+    required: false
+    default: '0'
 runs:
   using: 'composite'
   steps:
@@ -88,7 +92,8 @@ runs:
 
         # fetch the latest TCC agent version and make it executable
         echo "Downloading ${LATEST_BINARY_URL}"
-        curl -fsSL -o "${TCC_BINARY_NAME}" "${LATEST_BINARY_URL}"
+        RETRIES=${{ inputs.retry-attempts }}
+        curl -fsSL -o "${TCC_BINARY_NAME}" "${LATEST_BINARY_URL}" --retry "${RETRIES}" --retry-all-errors
         chmod +x ${TCC_BINARY_NAME}
         
         # start agent as background process

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,10 @@ inputs:
   project-url:
     description: 'Project URL'
     required: false
-  retry-attempts:
+  download-retries:
     description: 'The number of retry attempts to download Testcontainers Cloud Client before giving up'
     required: false
-    default: '0'
+    default: '1'
 runs:
   using: 'composite'
   steps:
@@ -69,6 +69,7 @@ runs:
         TC_CLOUD_TOKEN: ${{ inputs.token || env.TC_CLOUD_TOKEN }}
         TC_CLOUD_LOGS_ENABLE_COLORS: 'true'
         TCC_BINARY_NAME: ${{ env.TCC_BINARY_NAME || 'tcc-agent' }}
+        DOWNLOAD_RETRIES: ${{ inputs.download-retries }}
       if: inputs.action == 'prepare'
       run: |
         # download and run the agent at the background
@@ -92,8 +93,7 @@ runs:
 
         # fetch the latest TCC agent version and make it executable
         echo "Downloading ${LATEST_BINARY_URL}"
-        RETRIES=${{ inputs.retry-attempts }}
-        curl -fsSL -o "${TCC_BINARY_NAME}" "${LATEST_BINARY_URL}" --retry "${RETRIES}" --retry-all-errors
+        curl -fsSL -o "${TCC_BINARY_NAME}" "${LATEST_BINARY_URL}" --retry "${DOWNLOAD_RETRIES}" --retry-all-errors
         chmod +x ${TCC_BINARY_NAME}
         
         # start agent as background process


### PR DESCRIPTION
Downloading the client can fail due to various connectivity issues and having a retry mechanism would make actions much more stable